### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.1.2] - 2023-12-19
 
 ### Changed

--- a/helm/tempo/values.yaml
+++ b/helm/tempo/values.yaml
@@ -1,7 +1,7 @@
 global:
   image:
     # -- Overrides the Docker registry globally for all images, excluding enterprise.
-    registry: docker.io
+    registry: gsoci.azurecr.io
     # -- Optional list of imagePullSecrets for all images, excluding enterprise.
     # Names of existing secrets with private container registry credentials.
     # Ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -9,7 +9,7 @@ global:
     # pullSecrets: [ my-dockerconfigjson-secret ]
     pullSecrets: []
   # -- Overrides the priorityClassName for all pods
-  priorityClassName: null
+  priorityClassName:
   # -- configures cluster domain ("cluster.local" by default)
   clusterDomain: 'cluster.local'
   # -- configures DNS service name


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
