### PR TITLE
Disable usage reporting configuration to Grafana

### DIFF
--- a/helm/tempo/values.yaml
+++ b/helm/tempo/values.yaml
@@ -208,6 +208,8 @@ tempo:
 
   tempo:
     structuredConfig:
+      usage_report:
+        reporting_enabled: false
       # Support streaming of queries
       stream_over_http_enabled: true
     image:


### PR DESCRIPTION
This PR:

- disables usage reporting to Grafana
