### PR TITLE
Add ingress template for HTTP and gRPC traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ingress template for HTTP and gRPC traffic with configurable backends and auto-generated TLS configuration.
+
 ## [0.4.0] - 2025-09-29
 
 ### Added

--- a/helm/tempo/templates/ingress.yaml
+++ b/helm/tempo/templates/ingress.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.ingress.enabled -}}
+# Ingress resource to send traces to Tempo over HTTP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    {{- with .Values.ingress.http.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tempo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      {{- range .Values.ingress.http.backends }}
+      - backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
+        path: {{ .path }}
+        pathType: {{ .pathType }}
+      {{- end }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ include "tempo.fullname" . }}-tls
+---
+# Ingress resource to send traces to Tempo over gRPC protocol
+# Note: /opentelemetry and /tempopb paths cannot be changed due to how gRPC works
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    {{- with .Values.ingress.grpc.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "tempo.fullname" . }}-grpc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tempo.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      {{- range .Values.ingress.grpc.backends }}
+      - backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
+        path: {{ .path }}
+        pathType: {{ .pathType }}
+      {{- end }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ include "tempo.fullname" . }}-grpc-tls
+{{- end }}

--- a/helm/tempo/values.yaml
+++ b/helm/tempo/values.yaml
@@ -249,6 +249,32 @@ tempo:
       receiverConfig:
         max_recv_msg_size_mib: 1000000000
 
+ingress:
+  enabled: false
+  className: nginx
+  host: ""
+  http:
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+    backends:
+    - serviceName: tempo-distributor
+      servicePort: 4318
+      path: /tempo/(.*)
+      pathType: ImplementationSpecific
+  grpc:
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+    backends:
+    - serviceName: tempo-distributor
+      servicePort: 4317
+      path: /opentelemetry
+      pathType: ImplementationSpecific
+    - serviceName: tempo-ingester
+      servicePort: 3200
+      path: /tempopb
+      pathType: ImplementationSpecific
+
 vulture:
   # You can make tempo-vulture ineffective by setting this one to "false"
   enabled: true


### PR DESCRIPTION
## Summary
Add ingress template to the tempo helm chart for HTTP and gRPC traffic with configurable backends and auto-generated TLS configuration.

## Changes
- Add `helm/tempo/templates/ingress.yaml` with support for HTTP and gRPC ingresses
- Configurable backend arrays for flexible service routing
- Auto-generate TLS configuration from host
- Add default ingress values in `values.yaml`