### PR TITLE
Enable Tempo query-frontend MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable Tempo query-frontend MCP server (`/api/mcp` on `tempo-query-frontend:3200`, ClusterIP-only).
+
 ## [0.16.0] - 2026-04-22
 
 ### Changed

--- a/helm/tempo/values.schema.json
+++ b/helm/tempo/values.schema.json
@@ -386,6 +386,14 @@
                     "properties": {
                         "affinity": {
                             "type": "string"
+                        },
+                        "mcp_server": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 },

--- a/helm/tempo/values.yaml
+++ b/helm/tempo/values.yaml
@@ -273,6 +273,8 @@ tempo:
           - matchExpressions:
             - key: node-role.kubernetes.io/control-plane
               operator: DoesNotExist
+    mcp_server:
+      enabled: true
 
   rbac:
     pspEnabled: true


### PR DESCRIPTION
Sets `queryFrontend.mcp_server.enabled=true` on the `tempo-distributed` subchart.
`/api/mcp` stays ClusterIP-only — shared-configs only routes public traffic to the distributor.